### PR TITLE
fix: prefer mjs and pass jsx options to esbuild

### DIFF
--- a/examples/rnw-example/src/components/animated.stories.tsx
+++ b/examples/rnw-example/src/components/animated.stories.tsx
@@ -3,6 +3,9 @@ import { AnimatedLogo } from "./animated";
 
 const meta: Meta<typeof AnimatedLogo> = {
   component: AnimatedLogo,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/vite-plugin-rnw/package.json
+++ b/packages/vite-plugin-rnw/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.8",
+  "version": "0.0.9-0",
   "name": "vite-plugin-rnw",
   "type": "module",
   "author": "Daniel Williams",

--- a/packages/vite-plugin-rnw/src/index.ts
+++ b/packages/vite-plugin-rnw/src/index.ts
@@ -9,17 +9,19 @@ import { transformReanimatedWebUtilsWithMap } from "./transforms";
 import react, { type Options } from "@vitejs/plugin-react";
 
 const extensions = [
+  ".web.mjs",
   ".web.js",
+  ".web.mts",
   ".web.ts",
   ".web.tsx",
-  ".web.mjs",
   ".web.cjs",
+  ".mjs",
   ".js",
   ".jsx",
   ".json",
+  ".mts",
   ".ts",
   ".tsx",
-  ".mjs",
   ".cjs",
 ];
 
@@ -28,6 +30,19 @@ const defaultExcludeRE =
   /\/node_modules\/(?!react-native|@react-native|expo|@expo)/;
 
 export type RnwOptions = Options;
+
+const getJsxOption = (jsxRuntime: Options["jsxRuntime"]) => {
+  const jsxOptionMapping = {
+    automatic: "automatic",
+    classic: "transform",
+  } as const;
+
+  const jsxOption =
+    jsxRuntime && jsxRuntime in jsxOptionMapping
+      ? jsxOptionMapping[jsxRuntime]
+      : "automatic";
+  return jsxOption;
+};
 
 export function rnw(opts: RnwOptions = {}): Plugin[] {
   const include = opts.include ?? defaultIncludeRE;
@@ -58,6 +73,8 @@ export function rnw(opts: RnwOptions = {}): Plugin[] {
         optimizeDeps: {
           esbuildOptions: {
             resolveExtensions: extensions,
+            jsx: getJsxOption(opts.jsxRuntime),
+            jsxImportSource: opts.jsxImportSource,
             loader: {
               ".js": "jsx",
               ".mjs": "jsx",
@@ -139,9 +156,12 @@ export function rnw(opts: RnwOptions = {}): Plugin[] {
       name: "treat-js-files-as-jsx",
       async transform(code, id) {
         if (id.match(/\.js$/) || id.match(/\.mjs$/)) {
+          const jsxOption = getJsxOption(opts.jsxRuntime);
+
           return vite.transformWithEsbuild(code, id, {
             loader: "jsx",
-            jsx: "automatic",
+            jsx: jsxOption,
+            jsxImportSource: opts.jsxImportSource,
           });
         }
 


### PR DESCRIPTION
Updates mjs to be before js
passes jsx options down to more places