### PR TITLE
chore: add package homepage metadata

### DIFF
--- a/packages/vite-plugin-rnw/package.json
+++ b/packages/vite-plugin-rnw/package.json
@@ -27,6 +27,7 @@
     "type": "git",
     "url": "git+https://github.com/dannyhw/vite-plugin-rnw.git"
   },
+  "homepage": "https://github.com/dannyhw/vite-plugin-rnw#readme",
   "bugs": {
     "url": "https://github.com/dannyhw/vite-plugin-rnw/issues"
   },


### PR DESCRIPTION
## Summary
- Add the published package `homepage` metadata for `vite-plugin-rnw`.
- Point the homepage to the repository README.

## Verification
- `node -e "const p=require('./packages/vite-plugin-rnw/package.json'); console.log(JSON.stringify({name:p.name, version:p.version, homepage:p.homepage, bugs:p.bugs, repository:p.repository}, null, 2)); if(!p.homepage) process.exit(1)"`
- `git diff --check`
