### PR TITLE
fix: add package license metadata

### DIFF
--- a/packages/vite-plugin-rnw/package.json
+++ b/packages/vite-plugin-rnw/package.json
@@ -3,6 +3,7 @@
   "name": "vite-plugin-rnw",
   "type": "module",
   "author": "Daniel Williams",
+  "license": "MIT",
   "description": "Vite plugin for React Native Web",
   "keywords": [
     "vite",


### PR DESCRIPTION
## Summary
- Add the missing `license` metadata to `packages/vite-plugin-rnw/package.json`.
- The package already ships MIT license text in `LICENSE`, so this only makes the published npm metadata explicit.
- No runtime code, build config, exports, dependency, repository, homepage, or bugs metadata changed.

## Validation
- `node` package metadata assertion for name/version/license/repository/homepage/bugs
- `cd packages/vite-plugin-rnw && npm pack --dry-run --ignore-scripts --json`
- `git diff --check origin/main...HEAD`
