### PR TITLE
Move TypeScript to peer deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "dhw-rnw",
@@ -49,7 +48,7 @@
     },
     "packages/vite-plugin-rnw": {
       "name": "vite-plugin-rnw",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@rolldown/pluginutils": "^1.0.0-rc.9",
         "@vitejs/plugin-react": "^5.2.0",
@@ -60,11 +59,11 @@
       "devDependencies": {
         "@types/node": "^22",
         "tsdown": "^0.21.2",
+        "typescript": "^5",
         "vite": "^8.0.0",
       },
       "peerDependencies": {
         "react-native-web": "*",
-        "typescript": "^5",
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
       },
     },

--- a/packages/vite-plugin-rnw/package.json
+++ b/packages/vite-plugin-rnw/package.json
@@ -43,11 +43,11 @@
   "devDependencies": {
     "@types/node": "^22",
     "tsdown": "^0.21.2",
+    "typescript": "^5",
     "vite": "^8.0.0"
   },
   "peerDependencies": {
     "react-native-web": "*",
-    "typescript": "^5",
     "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #18.

I wanted to also upgraded TS to v6, or v7, but I wasn't sure if you'd want to use the semver major range `^` like most deps use, or the minor range `~` which is used only here: https://github.com/dannyhw/vite-plugin-rnw/blob/88b4a6a303fe8b8ccd445a4211e4b2a133b70e72/examples/rnw-example/package.json#L43