### PR TITLE
fix: respect user-provided defines

### DIFF
--- a/.changeset/respect-user-defines.md
+++ b/.changeset/respect-user-defines.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-rnw": patch
+---
+
+Respect user-provided `define` values: entries set in the user config now take precedence over the plugin defaults and are propagated to dependency optimization (e.g. production builds with `__DEV__: true`).

--- a/packages/vite-plugin-rnw/src/index.test.ts
+++ b/packages/vite-plugin-rnw/src/index.test.ts
@@ -48,3 +48,48 @@ test("uses the runtime defines during dependency optimization", async () => {
   );
   assert.equal(config.optimizeDeps?.rolldownOptions?.shimMissingExports, true);
 });
+
+test("user-provided defines take precedence over the plugin defaults", async () => {
+  const plugins = rnw().flat() as Plugin[];
+  const plugin = plugins.find(
+    (candidate) => candidate.name === "vite:react-native-web-babel",
+  );
+
+  assert.ok(plugin);
+  assert.equal(typeof plugin.config, "function");
+
+  if (typeof plugin.config !== "function") return;
+
+  const config = (await plugin.config.call(
+    {} as never,
+    {
+      define: {
+        // string values are kept as-is, non-strings are stringified like
+        // Vite does for the root `define`
+        __DEV__: "true",
+        _WORKLET: true,
+        // defines the plugin does not manage are left to Vite's own merging
+        "process.env.MY_APP_FLAG": JSON.stringify("on"),
+      },
+    },
+    {
+      command: "build",
+      mode: "production",
+      isPreview: false,
+      isSsrBuild: false,
+    },
+  )) as UserConfig;
+
+  assert.equal(config.define?.["__DEV__"], "true");
+  assert.equal(config.define?.["_WORKLET"], "true");
+  // defaults the user did not override are unchanged
+  assert.equal(config.define?.["global"], "window");
+  assert.equal(config.define?.["DEV"], "false");
+  // unmanaged user defines are not duplicated into the plugin's config
+  assert.equal("process.env.MY_APP_FLAG" in (config.define ?? {}), false);
+  // overrides are propagated to dependency optimization
+  assert.equal(
+    config.optimizeDeps?.rolldownOptions?.transform?.define?.["__DEV__"],
+    "true",
+  );
+});

--- a/packages/vite-plugin-rnw/src/index.ts
+++ b/packages/vite-plugin-rnw/src/index.ts
@@ -188,8 +188,17 @@ export function rnw(opts: RnwOptions = {}): Array<Plugin | Plugin[]> {
   const rnwPlugin: Plugin = {
     name: "vite:react-native-web-babel",
     enforce: "pre",
-    config(_userConfig, { mode }) {
-      const defines = getRuntimeDefines(mode);
+    config(userConfig, { mode }) {
+      const defines: Record<string, string> = { ...getRuntimeDefines(mode) };
+
+      // User-provided defines take precedence over the plugin defaults, and
+      // are propagated to dependency optimization so pre-bundled deps see the
+      // same values (e.g. a production build with `__DEV__: true`).
+      for (const [key, value] of Object.entries(userConfig.define ?? {})) {
+        if (key in defines) {
+          defines[key] = typeof value === "string" ? value : JSON.stringify(value);
+        }
+      }
 
       return {
         define: defines,


### PR DESCRIPTION
## Problem

The `config` hook of `vite:react-native-web-babel` ignores the user config (`_userConfig`) and returns its own `define` map. Since Vite merges plugin `config` results on top of the root user config, the plugin's values silently win over anything the user sets:

```ts
// vite.config.ts
export default defineConfig({
  plugins: [rnw()],
  define: { __DEV__: JSON.stringify(true) }, // silently ignored in production mode
})
```

Our use case: smart TV production builds that must keep `__DEV__: true` (some operators only accept release builds, even for QA/dev environments). Today the only workaround is a dedicated plugin placed right after `rnw()` that re-applies the define.

## Fix

- The hook now reads `userConfig.define`: user-provided entries for plugin-managed defines take precedence over the defaults.
- Overrides are propagated to the `optimizeDeps` defines added in 0.0.12, so pre-bundled deps see the same values as the bundle.
- Non-string values are stringified the same way Vite handles the root `define`.
- Defines the plugin does not manage are left untouched (Vite's own merging already handles them).

## Tests

Added a test alongside the existing define test: user overrides (string and non-string), untouched defaults, unmanaged keys, and propagation to `optimizeDeps`. `node --test`: 20/20 pass, `tsdown` build clean. A changeset (patch) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)